### PR TITLE
Fix Edge autoinstall path on Darwin

### DIFF
--- a/app/native-autoinstall.js
+++ b/app/native-autoinstall.js
@@ -152,7 +152,7 @@ function DarwinUninstall() {
 			"/Library/Application Support/Mozilla/NativeMessagingHosts/"+config.id+".json",
 			"/Library/Google/Chrome/NativeMessagingHosts/"+config.id+".json",
 			"/Library/Application Support/Chromium/NativeMessagingHosts/"+config.id+".json",
-			"/Library/Application Support/Microsoft Edge/NativeMessagingHosts/"+config.id+".json"
+			"/Library/Microsoft/Edge/NativeMessagingHosts/"+config.id+".json"
 		];
 	try {
 		manifests.forEach((file)=>{


### PR DESCRIPTION
The Darwin installer installs to `$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts/...` for user but `/Library/Microsoft/Edge/NativeMessagingHosts/...` for system. Something seems wrong there.

This is further corroborated by the uninstaller attempting to delete `/Library/Application Support/Microsoft Edge/NativeMessagingHosts/...` in system mode. This isn't going to do anything as the installer will never create anything at that path. Either the installer is creating the wrong system path or the uninstaller is uninstaller is deleting the wrong system path. I'm going to assume the former.