### PR TITLE
Adding Linux paths for Brave and Vivaldi config

### DIFF
--- a/app/native-autoinstall.js
+++ b/app/native-autoinstall.js
@@ -179,6 +179,12 @@ function LinuxInstall() {
 		},{
 			file: process.env.HOME+"/.config/chromium/NativeMessagingHosts/"+config.id+".json",
 			manifest: JSON.stringify(chromeManifest,null,4),
+		},{
+			file: process.env.HOME+"/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/"+config.id+".json",
+			manifest: JSON.stringify(chromeManifest,null,4),
+		},{
+			file: process.env.HOME+"/.config/vivaldi/NativeMessagingHosts/"+config.id+".json",
+			manifest: JSON.stringify(chromeManifest,null,4),
 		}];
 	else {
 		manifests = [{
@@ -221,7 +227,9 @@ function LinuxUninstall() {
 		manifests = [
 			process.env.HOME+"/.mozilla/native-messaging-hosts/"+config.id+".json",
 			process.env.HOME+"/.config/google-chrome/NativeMessagingHosts/"+config.id+".json",
-			process.env.HOME+"/.config/chromium/NativeMessagingHosts/"+config.id+".json"
+			process.env.HOME+"/.config/chromium/NativeMessagingHosts/"+config.id+".json",
+			process.env.HOME+"/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/"+config.id+".json",
+			process.env.HOME+"/.config/vivaldi/NativeMessagingHosts/"+config.id+".json"
 		];
 	else
 		manifests = [


### PR DESCRIPTION
Recently someone was able to package this into NixOS, although it only works through an user install. The changes added here are for setting/removing the manifests on Brave and Vivaldi on Linux (can confirm it works as intended).