### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@
 ***vdhcoapp*** complies with the [native messaging protocol](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging) and is not intended to be used directly from the command line.
 
 Installer executables for the various platforms are available from the [releases page](https://github.com/mi-g/vdhcoapp/releases).
+
+Note for Linux users: Firefox installations via snap or flathub is not yet supported.  Please install Firefox via the apt package.

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@
 
 Installer executables for the various platforms are available from the [releases page](https://github.com/mi-g/vdhcoapp/releases).
 
-Note for Linux users: Firefox installations via snap or flathub is not yet supported.  Please install Firefox via the apt package.
+Note for Linux users: Firefox installations via snap or flathub is not yet supported.  Please install Firefox via the native package manager, e.g. apt package for debian based distributions like Ubuntu.


### PR DESCRIPTION
Added a note to alert Linux users.  When Firefox is installed via Flathub or from the Snapstore, the coapp is not detected by the browser.  