### PR TITLE
Add support for system ffmpeg on Linux

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,3 +15,9 @@ jobs:
     - run: ./build.sh
     - run: sudo dpkg -i ./dist/linux/x86_64/vdhcoapp-linux-x86_64.deb
     - run: ./tests/test.mjs /opt/vdhcoapp/vdhcoapp --with-network
+    - run: sudo dpkg -r net.downloadhelper.coapp
+    - run: sudo apt-get update
+    - run: sudo apt-get install ffmpeg
+    - run: sudo dpkg -i ./dist/linux/x86_64/vdhcoapp-no-ffmpeg-2.0.9-linux-x86_64.deb
+    - run: ./tests/test.mjs /opt/vdhcoapp/vdhcoapp --with-network
+    - run: sudo dpkg -r net.downloadhelper.coapp.noffmpeg

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,6 @@ jobs:
     - run: sudo dpkg -r net.downloadhelper.coapp
     - run: sudo apt-get update
     - run: sudo apt-get install ffmpeg
-    - run: sudo dpkg -i ./dist/linux/x86_64/vdhcoapp-no-ffmpeg-2.0.9-linux-x86_64.deb
-    - run: ./tests/test.mjs /opt/vdhcoapp/vdhcoapp --with-network
+    - run: sudo dpkg -i ./dist/linux/x86_64/vdhcoapp-no-ffmpeg-linux-x86_64.deb
+    - run: ./tests/test.mjs /opt/vdhcoapp/vdhcoapp --with-network --no-ffmpeg-codecs-tests
     - run: sudo dpkg -r net.downloadhelper.coapp.noffmpeg

--- a/app/src/converter.js
+++ b/app/src/converter.js
@@ -9,7 +9,6 @@ const rpc = require('./weh-rpc');
 
 const exec_dir = path.dirname(process.execPath);
 
-const use_prebuilt_ffmpeg = fileExistsSync(ensureProgramExt(path.join(exec_dir, "ffmpeg")));
 const ffmpeg = findExecutableFullPath("ffmpeg", exec_dir);
 const ffprobe = findExecutableFullPath("ffprobe", exec_dir);
 
@@ -98,9 +97,7 @@ exports.star_listening = () => {
   const convertChildren = new Map();
 
   rpc.listen({
-    "use_prebuilt_ffmpeg": () => {
-      return Promise.resolve(use_prebuilt_ffmpeg);
-    },
+
     "abortConvert": (pid) => {
       let child = convertChildren.get(pid);
       if (child && child.exitCode == null) {

--- a/app/src/converter.js
+++ b/app/src/converter.js
@@ -9,6 +9,7 @@ const rpc = require('./weh-rpc');
 
 const exec_dir = path.dirname(process.execPath);
 
+const use_prebuilt_ffmpeg = fileExistsSync(ensureProgramExt(path.join(exec_dir, "ffmpeg")));
 const ffmpeg = findExecutableFullPath("ffmpeg", exec_dir);
 const ffprobe = findExecutableFullPath("ffprobe", exec_dir);
 
@@ -98,7 +99,9 @@ exports.star_listening = () => {
   const convertChildren = new Map();
 
   rpc.listen({
-
+    "use_prebuilt_ffmpeg": () => {
+      return Promise.resolve(use_prebuilt_ffmpeg);
+    },
     "abortConvert": (pid) => {
       let child = convertChildren.get(pid);
       if (child && child.exitCode == null) {

--- a/app/src/converter.js
+++ b/app/src/converter.js
@@ -2,17 +2,52 @@ import open from 'open';
 
 const os = require("os");
 const path = require('path');
+const fs = require("node:fs");
 
 const logger = require('./logger');
 const rpc = require('./weh-rpc');
 
 const exec_dir = path.dirname(process.execPath);
-let ffmpeg = path.join(exec_dir, "ffmpeg");
-let ffprobe = path.join(exec_dir, "ffprobe");
+let ffmpeg = ensureProgramExt(path.join(exec_dir, "ffmpeg"));
+let ffprobe = ensureProgramExt(path.join(exec_dir, "ffprobe"));
 
-if (os.platform() == "win32") {
-  ffmpeg += ".exe";
-  ffprobe += ".exe";
+function findExecutableFullPath (programName) {
+  const envPath = (process.env.PATH || '');
+  const foundExecutablePath = envPath.split(path.delimiter)
+    .map(x => path.join(x, programName))
+    .find(x => fileExistsSync(x));
+  return foundExecutablePath || ''
+}
+
+function fileExistsSync (filePath) {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch (error) {
+    return false;
+  }
+}
+
+function ensureProgramExt(programPath) {
+  if (os.platform() == "win32") {
+    return programPath + ".exe";
+  }
+  return programPath;
+}
+
+if (!fileExistsSync(ffmpeg)) {
+  ffmpeg = findExecutableFullPath("ffmpeg")
+}
+if (!fileExistsSync(ffprobe)) {
+  ffprobe = findExecutableFullPath("ffprobe")
+}
+
+if (!fileExistsSync(ffmpeg)) {
+  logger.error("ffmpeg not found. Please ensure if ffmpeg is installed and try again.");
+  process.exit(1);
+}
+if (!fileExistsSync(ffprobe)) {
+  logger.error("ffprobe not found. Please ensure if ffprobe is installed and try again.");
+  process.exit(1);
 }
 
 // Record all started processes, and kill them if the coapp

--- a/app/src/converter.js
+++ b/app/src/converter.js
@@ -8,15 +8,30 @@ const logger = require('./logger');
 const rpc = require('./weh-rpc');
 
 const exec_dir = path.dirname(process.execPath);
-let ffmpeg = ensureProgramExt(path.join(exec_dir, "ffmpeg"));
-let ffprobe = ensureProgramExt(path.join(exec_dir, "ffprobe"));
 
-function findExecutableFullPath (programName) {
+const ffmpeg = findExecutableFullPath("ffmpeg", exec_dir);
+const ffprobe = findExecutableFullPath("ffprobe", exec_dir);
+
+if (!fileExistsSync(ffmpeg)) {
+  logger.error("ffmpeg not found. Please ensure if ffmpeg is installed and try again.");
+  process.exit(1);
+}
+if (!fileExistsSync(ffprobe)) {
+  logger.error("ffprobe not found. Please ensure if ffprobe is installed and try again.");
+  process.exit(1);
+}
+
+function findExecutableFullPath(programName, extraPath = "") {
+  programName = ensureProgramExt(programName);
   const envPath = (process.env.PATH || '');
-  const foundExecutablePath = envPath.split(path.delimiter)
-    .map(x => path.join(x, programName))
-    .find(x => fileExistsSync(x));
-  return foundExecutablePath || ''
+  const pathArr = envPath.split(path.delimiter);
+  if (extraPath) {
+    pathArr.unshift(extraPath);
+  }
+  const foundExecutablePath = pathArr
+    .map((x) => path.join(x, programName))
+    .find((x) => fileExistsSync(x));
+  return foundExecutablePath || '';
 }
 
 function fileExistsSync (filePath) {
@@ -32,22 +47,6 @@ function ensureProgramExt(programPath) {
     return programPath + ".exe";
   }
   return programPath;
-}
-
-if (!fileExistsSync(ffmpeg)) {
-  ffmpeg = findExecutableFullPath("ffmpeg")
-}
-if (!fileExistsSync(ffprobe)) {
-  ffprobe = findExecutableFullPath("ffprobe")
-}
-
-if (!fileExistsSync(ffmpeg)) {
-  logger.error("ffmpeg not found. Please ensure if ffmpeg is installed and try again.");
-  process.exit(1);
-}
-if (!fileExistsSync(ffprobe)) {
-  logger.error("ffprobe not found. Please ensure if ffprobe is installed and try again.");
-  process.exit(1);
 }
 
 // Record all started processes, and kill them if the coapp

--- a/app/src/converter.js
+++ b/app/src/converter.js
@@ -29,10 +29,9 @@ function findExecutableFullPath(programName, extraPath = "") {
   if (extraPath) {
     pathArr.unshift(extraPath);
   }
-  const foundExecutablePath = pathArr
+  return pathArr
     .map((x) => path.join(x, programName))
     .find((x) => fileExistsSync(x));
-  return foundExecutablePath || '';
 }
 
 function fileExistsSync (filePath) {

--- a/build.sh
+++ b/build.sh
@@ -367,7 +367,7 @@ if [ ! $skip_packaging == 1 ]; then
     yq ".package.deb" ./config.toml -o yaml | \
       yq e ".package = \"${meta_id}.noffmpeg\"" |\
       yq e ".conflicts = \"${meta_id}\"" |\
-      yq e ".description = \"${meta_description} (No pre-built ffmpeg binary shipped; use ffmpeg on system instead)\"" |\
+      yq e ".description = \"${meta_description} (does not come with pre-built ffmpeg. Relies on system's ffmpeg)\"" |\
       yq e ".architecture = \"${deb_arch}\"" |\
       yq e ".depends = \"ffmpeg\"" |\
       yq e ".version = \"${meta_version}\"" > $target_dist_dir/deb/DEBIAN/control

--- a/build.sh
+++ b/build.sh
@@ -192,11 +192,17 @@ fi
 if [ $publish == 1 ]; then
   files=(
     "dist/linux/i686/$package_binary_name-linux-i686.tar.bz2"
+    "dist/linux/i686/$package_binary_name-no-ffmpeg-linux-i686.tar.bz2"
     "dist/linux/i686/$package_binary_name-linux-i686.deb"
+    "dist/linux/i686/$package_binary_name-no-ffmpeg-linux-i686.deb"
     "dist/linux/x86_64/$package_binary_name-linux-x86_64.tar.bz2"
+    "dist/linux/x86_64/$package_binary_name-no-ffmpeg-linux-x86_64.tar.bz2"
     "dist/linux/x86_64/$package_binary_name-linux-x86_64.deb"
+    "dist/linux/x86_64/$package_binary_name-no-ffmpeg-linux-x86_64.deb"
     "dist/linux/aarch64/$package_binary_name-linux-aarch64.tar.bz2"
+    "dist/linux/aarch64/$package_binary_name-no-ffmpeg-linux-aarch64.tar.bz2"
     "dist/linux/aarch64/$package_binary_name-linux-aarch64.deb"
+    "dist/linux/aarch64/$package_binary_name-no-ffmpeg-linux-aarch64.deb"
     "dist/mac/x86_64/$package_binary_name-mac-x86_64.dmg"
     "dist/mac/x86_64/$package_binary_name-mac-x86_64-installer.pkg"
     "dist/mac/arm64/$package_binary_name-mac-arm64.dmg"
@@ -283,6 +289,8 @@ yq . -o yaml ./config.toml | \
 
 out_deb_file="$package_binary_name-$target.deb"
 out_bz2_file="$package_binary_name-$target.tar.bz2"
+out_noffmpeg_deb_file="$package_binary_name-no-ffmpeg-$target.deb"
+out_noffmpeg_bz2_file="$package_binary_name-no-ffmpeg-$target.tar.bz2"
 out_pkg_file="$package_binary_name-$target-installer.pkg"
 out_dmg_file="$package_binary_name-$target.dmg"
 out_win_file="$package_binary_name-$target-installer.exe"
@@ -343,9 +351,52 @@ if [ ! $skip_packaging == 1 ]; then
 
   log "Packaging v$meta_version for $target"
 
+  # ===============================================
+  # LINUX
+  # ===============================================
   if [ $target_os == "linux" ]; then
     mkdir -p $target_dist_dir/deb/opt/$package_binary_name
     mkdir -p $target_dist_dir/deb/DEBIAN
+    # --------------------------------
+    # Variation: No ffmpeg shipped
+    # --------------------------------
+    cp LICENSE.txt README.md app/node_modules/open/xdg-open \
+      $target_dist_dir/$package_binary_name \
+      $target_dist_dir/deb/opt/$package_binary_name
+
+    yq ".package.deb" ./config.toml -o yaml | \
+      yq e ".package = \"${meta_id}.noffmpeg\"" |\
+      yq e ".conflicts = \"${meta_id}\"" |\
+      yq e ".description = \"${meta_description} (No pre-built ffmpeg binary shipped; use ffmpeg on system instead)\"" |\
+      yq e ".architecture = \"${deb_arch}\"" |\
+      yq e ".depends = \"ffmpeg\"" |\
+      yq e ".version = \"${meta_version}\"" > $target_dist_dir/deb/DEBIAN/control
+
+    ejs -f $target_dist_dir/config.json ./assets/linux/prerm.ejs \
+      > $target_dist_dir/deb/DEBIAN/prerm
+    chmod +x $target_dist_dir/deb/DEBIAN/prerm
+
+    ejs -f $target_dist_dir/config.json ./assets/linux/postinst.ejs \
+      > $target_dist_dir/deb/DEBIAN/postinst
+    chmod +x $target_dist_dir/deb/DEBIAN/postinst
+
+    log "Building .deb file"
+    dpkg-deb --build $target_dist_dir/deb $target_dist_dir/$out_noffmpeg_deb_file
+
+    rm -rf $target_dist_dir/$package_binary_name-$meta_version
+    mkdir $target_dist_dir/$package_binary_name-$meta_version
+    cp $target_dist_dir/deb/opt/$package_binary_name/* \
+      $target_dist_dir/$package_binary_name-$meta_version
+    log "Building .tar.bz2 file"
+    tar_extra=""
+    if [ $host_os == "mac" ]; then
+      tar_extra="--no-xattrs --no-mac-metadata"
+    fi
+    (cd $target_dist_dir && tar -cvjS $tar_extra -f $out_noffmpeg_bz2_file $package_binary_name-$meta_version)
+
+    # --------------------------------
+    # Variation: ffmpeg binary shipped
+    # --------------------------------
     cp LICENSE.txt README.md app/node_modules/open/xdg-open \
       $target_dist_dir/$package_binary_name \
       $target_dist_dir/ffmpeg \
@@ -353,10 +404,11 @@ if [ ! $skip_packaging == 1 ]; then
       $target_dist_dir/deb/opt/$package_binary_name
 
     yq ".package.deb" ./config.toml -o yaml | \
-      yq e ".package = \"$meta_id\"" |\
-      yq e ".description = \"$meta_description\"" |\
-      yq e ".architecture = \"$deb_arch\"" |\
-      yq e ".version = \"$meta_version\"" -o yaml > $target_dist_dir/deb/DEBIAN/control
+      yq e ".package = \"${meta_id}\"" |\
+      yq e ".conflicts = \"${meta_id}.noffmpeg\"" |\
+      yq e ".description = \"${meta_description} (With pre-built ffmpeg shipped.)\"" |\
+      yq e ".architecture = \"${deb_arch}\"" |\
+      yq e ".version = \"${meta_version}\"" > $target_dist_dir/deb/DEBIAN/control
 
     ejs -f $target_dist_dir/config.json ./assets/linux/prerm.ejs \
       > $target_dist_dir/deb/DEBIAN/prerm
@@ -384,6 +436,9 @@ if [ ! $skip_packaging == 1 ]; then
     rm -rf $target_dist_dir/deb
   fi
 
+  # ===============================================
+  # Mac
+  # ===============================================
   if [[ $node_os == "mac" ]]; then
     if ! [ -x "$(command -v create-dmg)" ]; then
       error "create-dmg not installed"
@@ -481,6 +536,10 @@ if [ ! $skip_packaging == 1 ]; then
     fi
   fi
 
+  # ===============================================
+  # Windows
+  # ===============================================
+
   if [ $node_os == "windows" ]; then
     install_dir=$target_dist_dir/install_dir
     mkdir -p $install_dir
@@ -536,7 +595,9 @@ if [ $target_os == "linux" ]; then
   log "Binary available: $target_dist_dir_rel/ffprobe"
   if [ ! $skip_packaging == 1 ]; then
     log "Deb file available: $target_dist_dir_rel/$out_deb_file"
+    log "Deb file available: $target_dist_dir_rel/$out_noffmpeg_deb_file"
     log "Tarball available: $target_dist_dir_rel/$out_bz2_file"
+    log "Tarball available: $target_dist_dir_rel/$out_noffmpeg_bz2_file"
   fi
 fi
 

--- a/tests/test.mjs
+++ b/tests/test.mjs
@@ -210,13 +210,18 @@ let old_coapp;
 }
 
 if (!old_coapp) {
-  const codecs = await exec("codecs");
-  assert_deep_equal("codecs", codecs, expected_codecs);
-  const formats = await exec("formats");
-  if (os.platform() == "darwin") {
-    assert_deep_equal("formats", formats, expected_formats);
+  const use_prebuilt_ffmpeg = await exec("use_prebuilt_ffmpeg");
+  if (use_prebuilt_ffmpeg) {
+    const codecs = await exec("codecs");
+    assert_deep_equal("codecs", codecs, expected_codecs);
+    const formats = await exec("formats");
+    if (os.platform() == "darwin") {
+      assert_deep_equal("formats", formats, expected_formats);
+    } else {
+      console.warn("Skipping format test as it fails on Linux and Windows");
+    }
   } else {
-    console.warn("Skipping format test as it fails on Linux and Windows");
+    console.warn("Skipping codecs and format tests as it fails when using ffmpeg provided by system.");
   }
 }
 


### PR DESCRIPTION
For the users who don't want to have pre-built `ffmpeg` binaries  (e.g. for saving disk storage) :

- Add an optional flag `--no-ship-ffmpeg` for `build.sh` (default is 0, which means won't change existing behavior by default)
- And also make `vdhcoapp` can search `ffmpeg`, `ffprobe` in PATH, and execute the existing `ffmpeg` in system.

Currently I've tested on Linux, and confirmed that `build.sh` can package `vdhcoapp` without shipping `ffmpeg` binaries, and still can correctly download video from YouTube. However Windows and MacOS are not tested because I have no systems can test.