### PR TITLE
Where to install the app in 64-bit machines

### DIFF
--- a/doc/Troubleshooting.md
+++ b/doc/Troubleshooting.md
@@ -4,6 +4,7 @@ If the coapp is not recognised by the extension, here are a few things you can t
 
 - Try the latest coapp. You will find the download links [here](https://www.downloadhelper.net/install-coapp-v2).
 - If you use Edge, make sure to install the addon from the Microsoft store, not the Google store. See relevant links [here](https://www.downloadhelper.net/install).
+- If you use a 64-bit machine, ensure that the installer places the application in the 'C:\Program Files (x86)' directory, rather than 'C:\Program Files'.
 
 ## Windows 7
 


### PR DESCRIPTION
I found that the extension doesn't recognize the app because the installer places it by default in the /Program Files (x86)/ directory. Manually changing the directory to /Program Files/ fixes the problem.